### PR TITLE
Fix Anki 25.x controller startup crash

### DIFF
--- a/README-ANKI-25X-COMPATIBILITY.md
+++ b/README-ANKI-25X-COMPATIBILITY.md
@@ -1,8 +1,24 @@
-# Anki 25.x compatibility patch
+# Anki 25.09.4 compatibility patch
 
-This branch contains a small compatibility patch for controller handling on
-newer Anki 25.x builds, including Anki 25.09.x with Python 3.13, Qt 6.9, and
-QtWebEngine.
+This branch contains an unofficial, vibe-coded compatibility patch for
+controller handling on newer Anki 25.x builds.
+
+It was tested on:
+
+```text
+Anki 25.09.4 (d52ca669)
+Python 3.13.5
+Qt 6.9.1
+Chromium 122
+macOS
+8BitDo Micro gamepad
+```
+
+The patch worked in that setup: Anki no longer crashed when the 8BitDo
+controller connected, and Contanki could be used again.
+
+This is intentionally a small patch, not a full rewrite of Contanki's
+controller backend.
 
 ## What it fixes
 
@@ -28,23 +44,109 @@ profile assumptions.
   reported button/axis counts do not trigger index errors.
 - Keeps existing controller profiles and bindings unchanged.
 
-## Installing this branch manually
+## No-code install option
 
-1. Download or clone this branch.
-2. Zip the contents of the `contanki/` directory as an `.ankiaddon` package.
-3. In Anki, open `Tools -> Add-ons -> Install from file...`.
-4. Select the generated `.ankiaddon` file.
-5. Restart Anki before testing a controller.
+If this pull request has a downloadable `.ankiaddon` file attached in the
+conversation or release where you found it, use that. That is the easiest path:
 
-Example packaging command from the repository root:
+1. Download the `.ankiaddon` file.
+2. Open Anki.
+3. Go to `Tools -> Add-ons`.
+4. Click `Install from file...`.
+5. Select the downloaded `.ankiaddon` file.
+6. Restart Anki completely.
+7. Connect your controller only after Anki has reopened.
+
+If Anki still shows two Contanki entries, disable the older/original one and
+leave the patched one enabled.
+
+## How to package this branch yourself
+
+These steps are written for non-programmers. You only need to make a zip file
+with the right contents and rename it to `.ankiaddon`.
+
+### Mac
+
+1. Open this pull request on GitHub.
+2. Click the green `Code` button.
+3. Click `Download ZIP`.
+4. Open the downloaded zip file. It will create a folder named something like
+   `anki-contanki-fix-anki-25x-gamepad-startup-crash`.
+5. Open that folder.
+6. Open the `contanki` folder inside it.
+7. Select everything inside the `contanki` folder, not the folder itself.
+8. Right-click the selected files and choose `Compress`.
+9. Rename the new zip file to:
+
+   ```text
+   contanki-anki25x-compat.ankiaddon
+   ```
+
+   If macOS warns about changing the extension, choose to use `.ankiaddon`.
+10. Open Anki.
+11. Go to `Tools -> Add-ons`.
+12. Disable or remove the old Contanki add-on if it is already installed.
+13. Click `Install from file...`.
+14. Pick `contanki-anki25x-compat.ankiaddon`.
+15. Restart Anki completely.
+16. After Anki restarts, connect your controller and test review controls.
+
+### Windows
+
+1. Open this pull request on GitHub.
+2. Click the green `Code` button.
+3. Click `Download ZIP`.
+4. Extract the downloaded zip file.
+5. Open the extracted folder.
+6. Open the `contanki` folder inside it.
+7. Select everything inside the `contanki` folder, not the folder itself.
+8. Right-click the selected files and choose `Send to -> Compressed (zipped)
+   folder`.
+9. Rename the new zip file to:
+
+   ```text
+   contanki-anki25x-compat.ankiaddon
+   ```
+
+   If Windows hides file extensions, enable `View -> File name extensions` in
+   File Explorer first.
+10. Open Anki.
+11. Go to `Tools -> Add-ons`.
+12. Disable or remove the old Contanki add-on if it is already installed.
+13. Click `Install from file...`.
+14. Pick `contanki-anki25x-compat.ankiaddon`.
+15. Restart Anki completely.
+16. After Anki restarts, connect your controller and test review controls.
+
+### Command-line packaging option
+
+If you are comfortable using Terminal or PowerShell, run this from the
+repository root:
 
 ```sh
 cd contanki
 zip -r ../contanki-anki25x-compat.ankiaddon . -x '__pycache__/*'
 ```
 
+Then install the generated `.ankiaddon` file from Anki's add-on manager.
+
+## What to do if it still crashes
+
+1. Restart Anki with the controller disconnected.
+2. Confirm only one Contanki add-on is enabled.
+3. Connect the controller after Anki is fully open.
+4. If it still crashes, test whether Anki opens normally when Contanki is
+   disabled.
+5. If reporting the issue, include:
+   - Anki version
+   - operating system
+   - controller model
+   - wired or Bluetooth connection
+   - whether Anki crashes immediately on connect or only after pressing a
+     button
+
 ## Verification notes
 
-This patch was verified against Anki 25.09.4 on macOS with an 8BitDo Micro
-controller. The add-on loaded cleanly under Anki's bundled Python 3.13, and the
-controller path no longer crashed when the controller connected.
+This patch was verified against Anki 25.09.4 (d52ca669) on macOS with an 8BitDo
+Micro controller. The add-on loaded cleanly under Anki's bundled Python 3.13,
+and the controller path no longer crashed when the controller connected.

--- a/README-ANKI-25X-COMPATIBILITY.md
+++ b/README-ANKI-25X-COMPATIBILITY.md
@@ -1,0 +1,50 @@
+# Anki 25.x compatibility patch
+
+This branch contains a small compatibility patch for controller handling on
+newer Anki 25.x builds, including Anki 25.09.x with Python 3.13, Qt 6.9, and
+QtWebEngine.
+
+## What it fixes
+
+Some users can see Anki crash or fail to initialize Contanki after connecting a
+controller. One observed failure mode is a JavaScript error like:
+
+```text
+Uncaught ReferenceError: get_controller_info is not defined
+```
+
+This can happen when Contanki asks the hidden controller webview for controller
+debug info before the injected script is ready. Newer Anki/QtWebEngine builds
+also appear less forgiving when `navigator.getGamepads()` is unavailable,
+returns sparse entries, or reports button/axis arrays that do not match the
+profile assumptions.
+
+## Changes in this branch
+
+- Guards all JavaScript `navigator.getGamepads()` access behind a safe helper.
+- Uses the `gamepadconnected` event's `event.gamepad` object when available.
+- Delays and guards Python calls to `get_controller_info()`.
+- Adds safe button and axis accessors in Python so controllers with mismatched
+  reported button/axis counts do not trigger index errors.
+- Keeps existing controller profiles and bindings unchanged.
+
+## Installing this branch manually
+
+1. Download or clone this branch.
+2. Zip the contents of the `contanki/` directory as an `.ankiaddon` package.
+3. In Anki, open `Tools -> Add-ons -> Install from file...`.
+4. Select the generated `.ankiaddon` file.
+5. Restart Anki before testing a controller.
+
+Example packaging command from the repository root:
+
+```sh
+cd contanki
+zip -r ../contanki-anki25x-compat.ankiaddon . -x '__pycache__/*'
+```
+
+## Verification notes
+
+This patch was verified against Anki 25.09.4 on macOS with an 8BitDo Micro
+controller. The add-on loaded cleanly under Anki's bundled Python 3.13, and the
+controller path no longer crashed when the controller connected.

--- a/contanki/contanki.py
+++ b/contanki/contanki.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 from collections import defaultdict
 
 from aqt import gui_hooks
-from aqt.qt import QAction, qconnect
+from aqt.qt import QAction, QTimer, qconnect
 from aqt.utils import current_window, tooltip
 from aqt.webview import AnkiWebView
 
@@ -63,6 +63,7 @@ class Contanki(AnkiWebView):
     script = _script
     scroll_up = False
     scroll_down = False
+    _debug_info_retry_count = 0
 
     def __init__(self, parent):
         super().__init__(parent=parent)
@@ -94,6 +95,7 @@ class Contanki(AnkiWebView):
     def resume(self):
         """Resumes the add-on"""
         self.stdHtml(f"""<script type="text/javascript">\n{self.script}\n</script>""")
+        QTimer.singleShot(250, self.update_debug_info)
 
     @property
     def profile(self) -> Profile | None:
@@ -166,6 +168,16 @@ class Contanki(AnkiWebView):
 
         return if_connected_wrapper
 
+    @staticmethod
+    def _button_pressed(buttons: list[bool], index: int | None) -> bool:
+        """Returns a button state without assuming the controller reported every index."""
+        return index is not None and 0 <= index < len(buttons) and buttons[index]
+
+    @staticmethod
+    def _axis_value(axes: list[float], index: int) -> float:
+        """Returns an axis value without assuming the controller reported every index."""
+        return axes[index] if 0 <= index < len(axes) else 0.0
+
     @if_connected
     def poll(self, input_buttons: str, input_axes: str) -> None:
         """Handles the polling of the controller"""
@@ -213,6 +225,8 @@ class Contanki(AnkiWebView):
         axes = [float(axis) for axis in input_axes.split(",")]
         while len(self.buttons) < len(buttons):
             self.buttons.append(buttons[len(self.buttons)])
+        while len(self.axes) < len(axes):
+            self.axes.append(False)
         self.controller_specific_fixes(buttons, axes)
         return buttons, axes
 
@@ -224,10 +238,12 @@ class Contanki(AnkiWebView):
             and any(axes)
             and not any(buttons[12:16])
         ):
-            buttons[12] = axes[1] < -0.5 or axes[3] < -0.5
-            buttons[13] = axes[1] > 0.5 or axes[3] > 0.5
-            buttons[14] = axes[0] < -0.5 or axes[2] < -0.5
-            buttons[15] = axes[0] > 0.5 or axes[2] > 0.5
+            while len(buttons) < 16:
+                buttons.append(False)
+            buttons[12] = self._axis_value(axes, 1) < -0.5 or self._axis_value(axes, 3) < -0.5
+            buttons[13] = self._axis_value(axes, 1) > 0.5 or self._axis_value(axes, 3) > 0.5
+            buttons[14] = self._axis_value(axes, 0) < -0.5 or self._axis_value(axes, 2) < -0.5
+            buttons[15] = self._axis_value(axes, 0) > 0.5 or self._axis_value(axes, 2) > 0.5
 
         if (
             self.profile.controller.parent == "8BitDo Zero (D Input)"
@@ -243,6 +259,8 @@ class Contanki(AnkiWebView):
         """Handles the polling of the controller when in the config dialog"""
         for i, value in enumerate(axes):
             pressed = abs(value) > 0.5
+            if i >= len(self.axes):
+                self.axes.append(False)
             if pressed != self.axes[i]:
                 changed.append((i + 200, pressed))
                 if pressed:
@@ -268,25 +286,44 @@ class Contanki(AnkiWebView):
         if (
             self.quick_select.settings["Select with D-Pad"]
             and self.profile.controller.dpad_buttons is not None
-            and any(buttons[index] for index in self.profile.controller.dpad_buttons)
+            and any(
+                self._button_pressed(buttons, index)
+                for index in self.profile.controller.dpad_buttons
+            )
         ):
             up, down, left, right = self.profile.controller.dpad_buttons
-            dpad_status = buttons[up], buttons[down], buttons[left], buttons[right]
+            dpad_status = (
+                self._button_pressed(buttons, up),
+                self._button_pressed(buttons, down),
+                self._button_pressed(buttons, left),
+                self._button_pressed(buttons, right),
+            )
             self.quick_select.dpad_select(state, dpad_status)
             for index in self.profile.controller.dpad_buttons:
-                self.buttons[index] = buttons[index]
+                if 0 <= index < len(buttons):
+                    while len(self.buttons) <= index:
+                        self.buttons.append(False)
+                    self.buttons[index] = buttons[index]
         elif self.profile.controller.has_stick:
-            self.quick_select.stick_select(state, axes[0], axes[1])
+            self.quick_select.stick_select(
+                state,
+                self._axis_value(axes, 0),
+                self._axis_value(axes, 1),
+            )
 
         if (
             (stick_button := self.profile.controller.stick_button) is not None
             and self.quick_select.settings["Do Action on Stick Press"]
-            and buttons[stick_button]
+            and self._button_pressed(buttons, stick_button)
         ):
             self.quick_select.disappear(True)
+            while len(self.buttons) <= stick_button:
+                self.buttons.append(False)
             self.buttons[stick_button] = buttons[stick_button]
-        elif buttons[0]:
+        elif self._button_pressed(buttons, 0):
             self.quick_select.disappear(True)
+            while len(self.buttons) <= 0:
+                self.buttons.append(False)
             self.buttons[0] = buttons[0]
 
     @if_connected
@@ -364,6 +401,8 @@ class Contanki(AnkiWebView):
                 continue
             action = self.profile.axes_bindings[axis]
             if action == "Buttons":
+                if axis >= len(self.axes):
+                    self.axes.extend([False] * (axis + 1 - len(self.axes)))
                 if abs(value) > 0.5 and not self.axes[axis]:
                     self.do_action(state, axis * 2 + (value > 0) + 100)
                 self.axes[axis] = abs(value) > 0.5
@@ -479,13 +518,20 @@ class Contanki(AnkiWebView):
 
     def update_debug_info(self):
         """Updates the debug info. View by pressing help in the config dialog."""
-        self._evalWithCallback("get_controller_info()", self._update_debug_info)
+        self._evalWithCallback(
+            "typeof get_controller_info === 'function' ? get_controller_info() : null",
+            self._update_debug_info,
+        )
 
     def _update_debug_info(self, controllers: str) -> None:
         """Callback to receive the controller info from the JavaScript interface"""
         if controllers is None:
             self.debug_info: list[list[str]] = []
+            if self._debug_info_retry_count < 12:
+                self._debug_info_retry_count += 1
+                QTimer.singleShot(250, self.update_debug_info)
         else:
+            self._debug_info_retry_count = 0
             self.debug_info = [
                 con.split("%") for con in controllers.split("%%%") if con
             ]

--- a/contanki/controller.js
+++ b/contanki/controller.js
@@ -1,6 +1,19 @@
 let polling, connected_index, indices, ready, mock_index;
 initialise();
 
+function send_message(message) {
+   bridgeCommand(`contanki::message::${message}`);
+}
+
+function safe_gamepads() {
+   try {
+      return window.navigator.getGamepads();
+   } catch (err) {
+      send_message(`Controller API error: ${err}`);
+      return [];
+   }
+}
+
 function initialise() {
    if (ready) {
       return;
@@ -18,8 +31,8 @@ function initialise() {
    mock = false;
 }
 
-function on_controller_connect() {
-   let controllers = window.navigator.getGamepads();
+function on_controller_connect(event) {
+   let controllers = safe_gamepads();
    let register = "contanki::register";
    indices = [];
    for (let i = 0; i < controllers.length; i++) {
@@ -36,17 +49,15 @@ function on_controller_connect() {
    } else if (indices.length > 1) {
       bridgeCommand(register);
    } else {
-      connect_controller(indices[0]);
+      connect_controller(indices[0], event && event.gamepad);
    }
 }
 
-function connect_controller(i) {
+function connect_controller(i, event_gamepad) {
    window.clearInterval(polling);
-   let con = window.navigator.getGamepads()[i];
+   let con = event_gamepad || safe_gamepads()[i];
    if (con == null) {
-      bridgeCommand(
-         "contanki::message::Could not find controller. Please reconnect your controller and try again."
-      );
+      send_message("Could not find controller. Please reconnect your controller and try again.");
       return;
    }
    bridgeCommand(`contanki::on_connect::${con.buttons.length}::${con.axes.length}::${con.id}`);
@@ -57,7 +68,7 @@ function connect_controller(i) {
 function on_controller_disconnect(event) {
    window.clearInterval(polling);
    connected_index = null;
-   let controllers = window.navigator.getGamepads();
+   let controllers = safe_gamepads();
    for (let i = 0; i < controllers.length; i++) {
       if (controllers[i] != null) {
          on_controller_connect(event);
@@ -72,7 +83,11 @@ function poll() {
       return;
    }
 
-   let con = window.navigator.getGamepads()[connected_index];
+   let con = safe_gamepads()[connected_index];
+   if (con == null) {
+      on_controller_disconnect("controller missing");
+      return;
+   }
 
    try {
       if (!con.connected) {
@@ -114,7 +129,7 @@ function mock_poll() {
 }
 
 function get_controller_info() {
-   let controllers = window.navigator.getGamepads();
+   let controllers = safe_gamepads();
    let ids = "";
    for (let i = 0; i < controllers.length; i++) {
       let con = controllers[i];


### PR DESCRIPTION
# Fix Anki 25.x controller startup crash and sparse gamepad reads

## Summary

This PR makes Contanki more defensive around the hidden controller webview used
for the JavaScript Gamepad API.

This is an unofficial, vibe-coded compatibility patch for newer Anki builds. It
was made to get Contanki working again after a controller-triggered crash on:

```text
Anki 25.09.4 (d52ca669)
Python 3.13.5
Qt 6.9.1
Chromium 122
macOS
8BitDo Micro gamepad
```

It worked in that setup: after applying the patch and restarting Anki, the
8BitDo controller could connect without crashing Anki.

It addresses a crash/initialization failure seen on newer Anki 25.x builds
where controller connection can coincide with the webview script not being
ready yet. One observed error before the process aborts is:

```text
Uncaught ReferenceError: get_controller_info is not defined
```

## What changed

- Wrap `navigator.getGamepads()` access in a safe JavaScript helper.
- Prefer the `gamepadconnected` event's `event.gamepad` object when present.
- Guard `get_controller_info()` calls until the injected script is available.
- Retry debug-info collection briefly after the webview is initialized.
- Add safe Python helpers for button and axis access so sparse/mismatched
  controller reports do not cause index errors.
- Preserve existing controller profiles, bindings, and configuration behavior.

## For non-programmer users

I added `README-ANKI-25X-COMPATIBILITY.md` with step-by-step packaging and
installation instructions for people who do not code. Short version:

1. Download this PR branch as a ZIP from GitHub.
2. Open the downloaded folder.
3. Open the `contanki` folder inside it.
4. Zip the contents of `contanki`, not the outer repo folder.
5. Rename the zip to `contanki-anki25x-compat.ankiaddon`.
6. In Anki, go to `Tools -> Add-ons -> Install from file...`.
7. Install the `.ankiaddon`.
8. Disable/remove the old Contanki if two Contanki entries appear.
9. Restart Anki completely.
10. Connect the controller after Anki has reopened.

## Tested

- `python3 -m py_compile contanki/contanki.py`
- `node --check contanki/controller.js`
- Packaged add-on zip integrity check
- Manual Anki 25.09.4 (d52ca669) macOS test with an 8BitDo Micro controller

## Notes

This is intentionally a narrow compatibility patch. It does not replace
Contanki's current JavaScript Gamepad API backend.

The repository's `contanki.tests.run_tests()` entry point was not runnable from
a plain shell because importing the add-on asserts that `aqt.mw` is available,
which requires a live Anki session.
